### PR TITLE
Add missing telnet namespace to Client type.

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ import (
 )
 
 func main() {
-	var caller Caller = telnet.StandardCaller
+	var caller telnet.Caller = telnet.StandardCaller
 
 	//@TOOD: replace "example.net:5555" with address you want to connect to.
 	telnet.DialToAndCall("example.net:5555", caller)
@@ -117,7 +117,7 @@ func main() {
 	//@TODO: Configure the TLS connection here, if you need to.
 	tlsConfig := &tls.Config{}
 
-	var caller Caller = telnet.StandardCaller
+	var caller telnet.Caller = telnet.StandardCaller
 
 	//@TOOD: replace "example.net:5555" with address you want to connect to.
 	telnet.DialToAndCallTLS("example.net:5555", caller, tlsConfig)

--- a/doc.go
+++ b/doc.go
@@ -41,7 +41,7 @@ DialToAndCall creates a (un-secure) TELNET client, which connects to a given add
 	)
 	
 	func main() {
-		var caller Caller = telnet.StandardCaller
+		var caller telnet.Caller = telnet.StandardCaller
 
 		//@TOOD: replace "example.net:23" with address you want to connect to.
 		telnet.DialToAndCall("example.net:23", caller)
@@ -64,7 +64,7 @@ DialToAndCallTLS creates a (secure) TELNETS client, which connects to a given ad
 		//@TODO: Configure the TLS connection here, if you need to.
 		tlsConfig := &tls.Config{}
 
-		var caller Caller = telnet.StandardCaller
+		var caller telnet.Caller = telnet.StandardCaller
 		
 		//@TOOD: replace "example.net:992" with address you want to connect to.
 		telnet.DialToAndCallTLS("example.net:992", caller, tlsConfig)


### PR DESCRIPTION
Just adding the missing telnet namespace to make the client examples compile.