### PR TITLE
Add Connection method with timeout support

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -1,11 +1,10 @@
 package telnet
 
-
 import (
 	"crypto/tls"
 	"net"
+	"time"
 )
-
 
 type Conn struct {
 	conn interface {
@@ -18,7 +17,6 @@ type Conn struct {
 	dataReader *internalDataReader
 	dataWriter *internalDataWriter
 }
-
 
 // Dial makes a (un-secure) TELNET client connection to the system's 'loopback address'
 // (also known as "localhost" or 127.0.0.1).
@@ -49,14 +47,43 @@ func DialTo(addr string) (*Conn, error) {
 	dataWriter := newDataWriter(conn)
 
 	clientConn := Conn{
-		conn:conn,
-		dataReader:dataReader,
-		dataWriter:dataWriter,
+		conn:       conn,
+		dataReader: dataReader,
+		dataWriter: dataWriter,
 	}
 
 	return &clientConn, nil
 }
 
+// DialToTimeout makes a (un-secure) TELNET client connection to the the address specified by
+// 'addr'.
+// Also a timeout could be specified.
+//
+// If a secure connection is desired, use `DialToTLS` instead.
+func DialToTimeout(addr string, timeout time.Duration) (*Conn, error) {
+
+	const network = "tcp"
+
+	if "" == addr {
+		addr = "127.0.0.1:telnet"
+	}
+
+	conn, err := net.DialTimeout(network, addr, timeout)
+	if nil != err {
+		return nil, err
+	}
+
+	dataReader := newDataReader(conn)
+	dataWriter := newDataWriter(conn)
+
+	clientConn := Conn{
+		conn:       conn,
+		dataReader: dataReader,
+		dataWriter: dataWriter,
+	}
+
+	return &clientConn, nil
+}
 
 // DialTLS makes a (secure) TELNETS client connection to the system's 'loopback address'
 // (also known as "localhost" or 127.0.0.1).
@@ -83,15 +110,44 @@ func DialToTLS(addr string, tlsConfig *tls.Config) (*Conn, error) {
 	dataWriter := newDataWriter(conn)
 
 	clientConn := Conn{
-		conn:conn,
-		dataReader:dataReader,
-		dataWriter:dataWriter,
+		conn:       conn,
+		dataReader: dataReader,
+		dataWriter: dataWriter,
 	}
 
 	return &clientConn, nil
 }
 
+// DialToTLS makes a (secure) TELNETS client connection to the the address specified by
+// 'addr'.
+// Also a timeout could be specified.
+func DialToTLSTimeout(addr string, timeout time.Duration, tlsConfig *tls.Config) (*Conn, error) {
 
+	const network = "tcp"
+
+	if "" == addr {
+		addr = "127.0.0.1:telnets"
+	}
+
+	d:= net.Dialer{
+		Timeout: timeout
+	}
+	conn, err := tls.DialWithDialer(d, network, addr, tlsConfig)
+	if nil != err {
+		return nil, err
+	}
+
+	dataReader := newDataReader(conn)
+	dataWriter := newDataWriter(conn)
+
+	clientConn := Conn{
+		conn:       conn,
+		dataReader: dataReader,
+		dataWriter: dataWriter,
+	}
+
+	return &clientConn, nil
+}
 
 // Close closes the client connection.
 //
@@ -107,7 +163,6 @@ func (clientConn *Conn) Close() error {
 	return clientConn.conn.Close()
 }
 
-
 // Read receives `n` bytes sent from the server to the client,
 // and "returns" into `p`.
 //
@@ -122,7 +177,6 @@ func (clientConn *Conn) Read(p []byte) (n int, err error) {
 	return clientConn.dataReader.Read(p)
 }
 
-
 // Write sends `n` bytes from 'p' to the server.
 //
 // Note that Write can only be used for sending TELNET (and TELNETS) data to the server.
@@ -135,12 +189,10 @@ func (clientConn *Conn) Write(p []byte) (n int, err error) {
 	return clientConn.dataWriter.Write(p)
 }
 
-
 // LocalAddr returns the local network address.
 func (clientConn *Conn) LocalAddr() net.Addr {
 	return clientConn.conn.LocalAddr()
 }
-
 
 // RemoteAddr returns the remote network address.
 func (clientConn *Conn) RemoteAddr() net.Addr {

--- a/conn.go
+++ b/conn.go
@@ -130,7 +130,7 @@ func DialToTLSTimeout(addr string, timeout time.Duration, tlsConfig *tls.Config)
 	}
 
 	d := net.Dialer{Timeout: timeout}
-	conn, err := tls.DialWithDialer(d, network, addr, tlsConfig)
+	conn, err := tls.DialWithDialer(&d, network, addr, tlsConfig)
 	if nil != err {
 		return nil, err
 	}

--- a/conn.go
+++ b/conn.go
@@ -129,9 +129,7 @@ func DialToTLSTimeout(addr string, timeout time.Duration, tlsConfig *tls.Config)
 		addr = "127.0.0.1:telnets"
 	}
 
-	d:= net.Dialer{
-		Timeout: timeout
-	}
+	d := net.Dialer{Timeout: timeout}
 	conn, err := tls.DialWithDialer(d, network, addr, tlsConfig)
 	if nil != err {
 		return nil, err


### PR DESCRIPTION
For a personal project I needed that telnet should quickly connect or fail after a timeout.

I added two new methods to allow to specify Timeout using `time.Duration`.